### PR TITLE
In zsh prompt_pwd use indexes rather than strings

### DIFF
--- a/shell/zsh/prompt.zsh
+++ b/shell/zsh/prompt.zsh
@@ -49,7 +49,13 @@ function prompt_pwd() {
       parts[i]="%U$part%u"
     elif [[ $i != ${#parts} ]]; then
       # shorten the path as long as it isn't the last piece
-      parts[i]="$part[1,1]"
+      if [[ $part[1,1] == "." ]]; then
+        # if this part of the path starts with a dot, then keep
+        # the 2nd letter aswell
+        parts[i]="$part[1,2]"
+      else
+        parts[i]="$part[1,1]"
+      fi
     fi
   done
 


### PR DESCRIPTION
otherwise if two directories in the heirarchy have the same name, they
will both not be shortened when one should be.

Also when shortening dir names, keep two letters when 1st is . (dot)

(I copied the prompt_pwd function into my own zsh, found it wasn't always working as intended and fixed it, so here are my fixes if you want them).
