### PR TITLE
Fix insecure gem fetching

### DIFF
--- a/config/gemrc
+++ b/config/gemrc
@@ -3,7 +3,7 @@
 :benchmark: false
 :bulk_threshold: 1000
 :sources:
-- http://rubygems.org/
+- https://rubygems.org/
 :update_sources: true
 :verbose: true
 gem: --no-ri --no-rdoc


### PR DESCRIPTION
Should be using https to fetch gems rather than http.
